### PR TITLE
Add DMG creation script

### DIFF
--- a/DMG/create-dmg.sh
+++ b/DMG/create-dmg.sh
@@ -1,0 +1,13 @@
+brew install create-dmg
+rm -rf Alby-Installer.dmg
+create-dmg \
+  --volname "Alby Installer" \
+  --window-size 800 400 \
+  --icon-size 100 \
+  --icon "Alby.app" 200 190 \
+  --hide-extension "Alby.app" \
+  --app-drop-link 600 185 \
+  --no-internet-enable \
+  --hdiutil-quiet \
+  "Alby-Installer.dmg" \
+  "dmg_content/"

--- a/README.md
+++ b/README.md
@@ -3,9 +3,31 @@
 This is the Extension and Companion Installer for **[Alby](http://getalby.com)**.
 ![](dark.png)
 
+## Usage
+
 1. Clicking on the first line will open the browser with the extension's URL which will install it.
 2. Clicking the second line will copy `alby.json` into the `NativeMessagingHosts` folder in your `Libary/Application Support` for the browser.
 
 Enjoy the code and please report any bugs.
+
+## Build
+
+Build App:
+
+1. Clone project.
+2. Open `Alby.xcodeproj`, press: `Prooduct` -> `Archive` -> `Distribute App`. 
+3. Select appropriate signing and distribution options and generate `Alby.app` bundle.
+
+Generate installer (Optional):
+
+1. Place `Alby.app` under `alby-installer-macos/DMG/dmg_content/` directory (There's a placeholder file there - just replace it).
+2. Using Terminal:
+```shell
+cd .../alby-installer-macos/DMG/
+zsh create-dmg.sh
+open .
+```
+3. Finder is open on folder with `.dmg` installer - reay for use.
+
 
 👋 Author: [StuFF mc](https://github.com/stuffmc)


### PR DESCRIPTION
Added a script for DMG creation. 
Script should be invoked in the DMG directory. 
It takes "Alby.app" from "dmg_content" directory and creates a DMG file

Resolves #1